### PR TITLE
Fix loop in strict/longest mode

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -101,7 +101,6 @@ copyright: false
     1. Let _closure_ be a new Abstract Closure with no parameters that captures _iters_, _iterCount_, _openIters_, _mode_, _padding_, and _finishResults_, and performs the following steps when called:
       1. Repeat,
         1. Let _results_ be a new empty List.
-        1. Let _observedStrictEnding_ be *false*.
         1. For each integer _i_ such that 0 ≤ _i_ &lt; _iterCount_, in ascending order, do
           1. If _iters_[_i_] is *null*, then
             1. Let _result_ be _padding_[_i_].
@@ -116,15 +115,24 @@ copyright: false
               1. If _mode_ is ~shortest~, then
                 1. Return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
               1. Else if _mode_ is ~strict~, then
-                1. If _observedStrictEnding_ is *false* and _i_ ≠ 0, then
+                1. If _i_ ≠ 0, then
                   1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
-                1. Set _observedStrictEnding_ to *true*.
+                1. Else,
+                  1. For each integer _k_ such that 1 ≤ k ≤ _iterCount_, in ascending order, do
+                    1. Let _open_ be Completion(IteratorStep(_iters_[_k_])).
+                    1. If _result_ is an abrupt completion, then
+                      1. Remove _iters_[_k_] from _openIters_.
+                      1. Return ? IteratorCloseAll(_openIters_, _result_).
+                    1. If _open_ is *false*, then
+                      1. Remove _iters_[_k_] from _openIters_.
+                    1. Else,
+                      1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
+                1. Return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
               1. Else,
                 1. Assert: _mode_ is ~longest~.
+                1. If _openIters_ is empty, return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
                 1. Set _iters_[_i_] to *null*.
                 1. Set _result_ to _padding_[_i_].
-            1. Else if _observedStrictEnding_ is *true*, then
-              1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
           1. Append _result_ to _results_.
         1. Set _results_ to _finishResults_(_results_).
         1. Let _completion_ be Completion(Yield(_results_)).

--- a/spec.emu
+++ b/spec.emu
@@ -117,20 +117,19 @@ copyright: false
               1. Else if _mode_ is ~strict~, then
                 1. If _i_ ≠ 0, then
                   1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
-                1. Else,
-                  1. For each integer _k_ such that 1 ≤ k &lt; _iterCount_, in ascending order, do
-                    1. Let _open_ be Completion(IteratorStep(_iters_[_k_])).
-                    1. If _result_ is an abrupt completion, then
-                      1. Remove _iters_[_k_] from _openIters_.
-                      1. Return ? IteratorCloseAll(_openIters_, _result_).
-                    1. If _open_ is *false*, then
-                      1. Remove _iters_[_k_] from _openIters_.
-                    1. Else,
-                      1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
-                1. Return NormalCompletion(*undefined*).
+                1. For each integer _k_ such that 1 ≤ k &lt; _iterCount_, in ascending order, do
+                  1. Let _open_ be Completion(IteratorStep(_iters_[_k_])).
+                  1. If _result_ is an abrupt completion, then
+                    1. Remove _iters_[_k_] from _openIters_.
+                    1. Return ? IteratorCloseAll(_openIters_, _result_).
+                  1. If _open_ is *false*, then
+                    1. Remove _iters_[_k_] from _openIters_.
+                  1. Else,
+                    1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
+                1. Return *undefined*.
               1. Else,
                 1. Assert: _mode_ is ~longest~.
-                1. If _openIters_ is empty, return NormalCompletion(*undefined*).
+                1. If _openIters_ is empty, return *undefined*.
                 1. Set _iters_[_i_] to *null*.
                 1. Set _result_ to _padding_[_i_].
           1. Append _result_ to _results_.

--- a/spec.emu
+++ b/spec.emu
@@ -127,7 +127,7 @@ copyright: false
                       1. Remove _iters_[_k_] from _openIters_.
                     1. Else,
                       1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
-                1. Return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
+                1. Return NormalCompletion(*undefined*).
               1. Else,
                 1. Assert: _mode_ is ~longest~.
                 1. If _openIters_ is empty, return NormalCompletion(*undefined*).

--- a/spec.emu
+++ b/spec.emu
@@ -118,7 +118,7 @@ copyright: false
                 1. If _i_ ≠ 0, then
                   1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
                 1. Else,
-                  1. For each integer _k_ such that 1 ≤ k ≤ _iterCount_, in ascending order, do
+                  1. For each integer _k_ such that 1 ≤ k &lt; _iterCount_, in ascending order, do
                     1. Let _open_ be Completion(IteratorStep(_iters_[_k_])).
                     1. If _result_ is an abrupt completion, then
                       1. Remove _iters_[_k_] from _openIters_.
@@ -130,7 +130,7 @@ copyright: false
                 1. Return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
               1. Else,
                 1. Assert: _mode_ is ~longest~.
-                1. If _openIters_ is empty, return ? IteratorCloseAll(_openIters_, NormalCompletion(*undefined*)).
+                1. If _openIters_ is empty, return NormalCompletion(*undefined*).
                 1. Set _iters_[_i_] to *null*.
                 1. Set _result_ to _padding_[_i_].
           1. Append _result_ to _results_.


### PR DESCRIPTION
Based on #15; just look at the second commit if that hasn't landed yet.

Without this change, there is no way to get a normal exit in the `~strict~` or `~longest~` modes.