### PR TITLE
clarify iterator lists

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -25,18 +25,16 @@ copyright: false
       1. Set _paddingOption_ to ? Get(_options_, *"padding"*).
     1. If _strict_ is *true*, set _mode_ to ~strict~.
     1. Let _iters_ be a new empty List.
-    1. Let _openIters_ be a new empty List.
     1. Let _padding_ be a new empty List.
     1. Let _inputIter_ be ? GetIterator(_iterables_, ~sync~).
     1. Let _next_ be ~not-started~.
     1. Repeat, while _next_ is not ~done~,
       1. Set _next_ to Completion(IteratorStepValue(_inputIter_)).
-      1. IfAbruptCloseIterators(_next_, _openIters_).
+      1. IfAbruptCloseIterators(_next_, _iters_).
       1. If _next_ is not ~done~, then
         1. Let _iter_ be Completion(GetIteratorFlattenable(_next_, ~iterate-strings~)).
-        1. IfAbruptCloseIterators(_iter_, the list-concatenation of « _inputIter_ » and _openIters_).
+        1. IfAbruptCloseIterators(_iter_, the list-concatenation of « _inputIter_ » and _iters_).
         1. Append _iter_ to _iters_.
-        1. Append _iter_ to _openIters_.
     1. Let _iterCount_ be the number of elements in _iters_.
     1. If _mode_ is ~longest~, then
       1. If _paddingOption_ is *undefined*, then
@@ -44,12 +42,12 @@ copyright: false
           1. Append *undefined* to _padding_.
       1. Else,
         1. Let _paddingIter_ be Completion(GetIterator(_paddingOption_, ~sync~)).
-        1. IfAbruptCloseIterators(_paddingIter_, _openIters_).
+        1. IfAbruptCloseIterators(_paddingIter_, _iters_).
         1. Let _usingIterator_ be *true*.
         1. Perform the following steps _iterCount_ times:
           1. If _usingIterator_ is *true*, then
             1. Set _next_ to Completion(IteratorStepValue(_paddingIter_)).
-            1. IfAbruptCloseIterators(_next_, _openIters_).
+            1. IfAbruptCloseIterators(_next_, _iters_).
             1. If _next_ is ~done~, then
               1. Set _usingIterator_ to *false*.
             1. Else,
@@ -57,10 +55,9 @@ copyright: false
           1. If _usingIterator_ is *false*, append *undefined* to _padding_.
         1. If _usingIterator_ is *true*, then
           1. Let _completion_ be Completion(IteratorClose(_paddingIter_, NormalCompletion(~unused~))).
-          1. IfAbruptCloseIterators(_completion_, _openIters_).
+          1. IfAbruptCloseIterators(_completion_, _iters_).
     1. Let _finishResults_ be a new Abstract Closure with parameters (_results_) that captures nothing and performs the following steps when called:
       1. Return CreateArrayFromList(_results_).
-    1. Assert: _iters_ and _openIters_ have the same length and elements.
     1. Return IteratorZipCore(_iters_, _mode_, _padding_, _finishResults_).
   </emu-alg>
 </emu-clause>
@@ -81,7 +78,6 @@ copyright: false
       1. Set _paddingOption_ to ? Get(_options_, *"padding"*).
     1. If _strict_ is *true*, set _mode_ to ~strict~.
     1. Let _iters_ be a new empty List.
-    1. Let _openIters_ be a new empty List.
     1. Let _padding_ be a new empty List.
     1. Let _allKeys_ be ? _iterables_.[[OwnPropertyKeys]]().
     1. Let _keys_ be a new empty List.
@@ -96,14 +92,13 @@ copyright: false
           1. Let _getter_ be _desc_.[[Get]].
           1. If _getter_ is not *undefined*, then
             1. Let _getterResult_ be Completion(Call(_getter_, _iterables_)).
-            1. IfAbruptCloseIterators(_getterResult_, _openIters_).
+            1. IfAbruptCloseIterators(_getterResult_, _iters_).
             1. Set _value_ to _getterResult_.
         1. If _value_ is not *undefined*, then
           1. Append _key_ to _keys_.
           1. Let _iter_ be Completion(GetIteratorFlattenable(_value_, ~iterate-strings~)).
-          1. IfAbruptCloseIterators(_iter_, _openIters_).
+          1. IfAbruptCloseIterators(_iter_, _iters_).
           1. Append _iter_ to _iters_.
-          1. Append _iter_ to _openIters_.
     1. Let _iterCount_ be the number of elements in _iters_.
     1. If _mode_ is ~longest~, then
       1. If _paddingOption_ is *undefined*, then
@@ -112,14 +107,13 @@ copyright: false
       1. Else,
         1. For each element _key_ of _keys_, do
           1. Let _value_ be Completion(Get(_paddingOption_, _key_)).
-          1. IfAbruptCloseIterators(_value_, _openIters_).
+          1. IfAbruptCloseIterators(_value_, _iters_).
           1. Append _value_ to _padding_.
     1. Let _finishResults_ be a new Abstract Closure with parameters (_results_) that captures _keys_ and _iterCount_ and performs the following steps when called:
       1. Let _obj_ be OrdinaryObjectCreate(*null*).
       1. For each integer _i_ such that 0 ≤ _i_ &lt; _iterCount_, do
         1. Perform ! CreateDataPropertyOrThrow(_obj_, _keys_[_i_], _results_[_i_]).
       1. Return _obj_.
-    1. Assert: _iters_ and _openIters_ have the same length and elements.
     1. Return IteratorZipCore(_iters_, _mode_, _padding_, _finishResults_).
   </emu-alg>
 </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -60,7 +60,8 @@ copyright: false
           1. IfAbruptCloseIterators(_completion_, _openIters_).
     1. Let _finishResults_ be a new Abstract Closure with parameters (_results_) that captures nothing and performs the following steps when called:
       1. Return CreateArrayFromList(_results_).
-    1. Return IteratorZipCore(_iters_, _openIters_, _mode_, _padding_, _finishResults_).
+    1. Assert: _iters_ and _openIters_ have the same length and elements.
+    1. Return IteratorZipCore(_iters_, _mode_, _padding_, _finishResults_).
   </emu-alg>
 </emu-clause>
 
@@ -118,7 +119,8 @@ copyright: false
       1. For each integer _i_ such that 0 ≤ _i_ &lt; _iterCount_, do
         1. Perform ! CreateDataPropertyOrThrow(_obj_, _keys_[_i_], _results_[_i_]).
       1. Return _obj_.
-    1. Return IteratorZipCore(_iters_, _openIters_, _mode_, _padding_, _finishResults_).
+    1. Assert: _iters_ and _openIters_ have the same length and elements.
+    1. Return IteratorZipCore(_iters_, _mode_, _padding_, _finishResults_).
   </emu-alg>
 </emu-clause>
 
@@ -126,7 +128,6 @@ copyright: false
   <h1>
     IteratorZipCore (
       _iters_: a List of Iterator Records,
-      _openIters_: a List of Iterator Records,
       _mode_: either ~shortest~, ~longest~, or ~strict~,
       _padding_: a List of ECMAScript language values,
       _finishResults_: an Abstract Closure that takes a List of ECMAScript values and returns an ECMAScript value,
@@ -138,10 +139,12 @@ copyright: false
   </dl>
   <emu-alg>
     1. Let _iterCount_ be the number of elements in _iters_.
+    1. Let _openIters_ be a copy of _iters_.
     1. Let _closure_ be a new Abstract Closure with no parameters that captures _iters_, _iterCount_, _openIters_, _mode_, _padding_, and _finishResults_, and performs the following steps when called:
       1. If _iterCount_ = 0, return *undefined*.
       1. Repeat,
         1. Let _results_ be a new empty List.
+        1. Assert: _openIters_ is not empty.
         1. For each integer _i_ such that 0 ≤ _i_ &lt; _iterCount_, in ascending order, do
           1. If _iters_[_i_] is *null*, then
             1. Let _result_ be _padding_[_i_].
@@ -159,6 +162,7 @@ copyright: false
                 1. If _i_ ≠ 0, then
                   1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).
                 1. For each integer _k_ such that 1 ≤ _k_ &lt; _iterCount_, in ascending order, do
+                  1. Assert: _iters_[_k_] is not *null*.
                   1. Let _open_ be Completion(IteratorStep(_iters_[_k_])).
                   1. If _open_ is an abrupt completion, then
                     1. Remove _iters_[_k_] from _openIters_.


### PR DESCRIPTION
Revisiting this I found some parts confusing, so I've tweaked it a bit to clarify.

The `Assert: _openIters_ is not empty.` step won't be true until after https://github.com/tc39/proposal-joint-iteration/pull/20 lands.

An alternative to replacing elements of `_iters_` with `null` and tracking `_openIters_` as separate list could be to just rely on the `[[Done]]` field of Iterator Records. That would require updating IteratorCloseAll to filter out the `[[Done]]: true` ones, though.