### PR TITLE
`ziptoObjects` → `zipKeyed`

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -31,12 +31,12 @@
   [0, 1, 2],
   [3, 4, 5],
 ]))</code></pre>
-    <pre><code>Array.from(Iterator.zipToObjects({
+    <pre><code>Array.from(Iterator.zipKeyed({
   a: [0, 1, 2],
   b: [3, 4, 5, 6],
   c: [7, 8, 9],
 }))</code></pre>
-    <pre><code>Array.from(Iterator.zipToObjects({
+    <pre><code>Array.from(Iterator.zipKeyed({
   a: [0, 1, 2],
   b: [3, 4, 5, 6],
   c: [7, 8, 9],

--- a/spec.emu
+++ b/spec.emu
@@ -61,8 +61,8 @@ copyright: false
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-iterator.ziptoobjects">
-  <h1>Iterator.zipToObjects ( _iterables_ [ , _options_ ] )</h1>
+<emu-clause id="sec-iterator.zipkeyed">
+  <h1>Iterator.zipKeyed ( _iterables_ [ , _options_ ] )</h1>
   <p>This method performs the following steps when called:</p>
   <emu-alg>
     1. If _iterables_ is not an Object, throw a *TypeError* exception.

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,8 @@ function* zip(input: unknown, options?: unknown): IterableIterator<Array<unknown
   yield* zipCore(iters, mode, padding);
 }
 
-function zipToObjects<P extends { readonly [item: PropertyKey]: IteratorOrIterable<unknown> }>(p: P, o?: ZipOptions<NamedIteratees<P>>): IterableIterator<NamedIteratees<P>>
-function* zipToObjects(input: unknown, options?: unknown): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
+function zipKeyed<P extends { readonly [item: PropertyKey]: IteratorOrIterable<unknown> }>(p: P, o?: ZipOptions<NamedIteratees<P>>): IterableIterator<NamedIteratees<P>>
+function* zipKeyed(input: unknown, options?: unknown): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
   if (!isObject(input)) {
     throw new TypeError;
   }
@@ -207,9 +207,9 @@ Object.defineProperty(Iterator, 'zip', {
   value: zip,
 });
 
-Object.defineProperty(Iterator, 'zipToObjects', {
+Object.defineProperty(Iterator, 'zipKeyed', {
   configurable: true,
   writable: true,
   enumerable: false,
-  value: zipToObjects,
+  value: zipKeyed,
 });

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -39,7 +39,7 @@ test('basic positional', async t => {
   });
 
   await t.test('strict', () => {
-    let result = 
+    let result =
       Iterator.zip([
         [0],
         [1, 2],
@@ -52,7 +52,7 @@ test('basic positional', async t => {
 
 test('basic named', async t => {
   await t.test('shortest', () => {
-    assert.deepEqual(Array.from(Iterator.zipToObjects({
+    assert.deepEqual(Array.from(Iterator.zipKeyed({
       a: [0],
       b: [1, 2],
     })), [
@@ -61,7 +61,7 @@ test('basic named', async t => {
   });
 
   await t.test('equiv', () => {
-    assert.deepEqual(Array.from(Iterator.zipToObjects({
+    assert.deepEqual(Array.from(Iterator.zipKeyed({
       a: [0, 1, 2],
       b: [3, 4, 5],
       c: [6, 7, 8],
@@ -73,11 +73,11 @@ test('basic named', async t => {
   });
 
   await t.test('empty', () => {
-    assert.deepEqual(Array.from(Iterator.zipToObjects({})), []);
+    assert.deepEqual(Array.from(Iterator.zipKeyed({})), []);
   });
 
   await t.test('longest', () => {
-    assert.deepEqual(Array.from(Iterator.zipToObjects({
+    assert.deepEqual(Array.from(Iterator.zipKeyed({
       a: [0],
       b: [1, 2],
     }, { mode: 'longest' })), [
@@ -87,8 +87,8 @@ test('basic named', async t => {
   });
 
   await t.test('strict', () => {
-    let result = 
-      Iterator.zipToObjects({
+    let result =
+      Iterator.zipKeyed({
         a: [0],
         b: [1, 2],
       }, { mode: 'strict' });
@@ -136,7 +136,7 @@ test('padding', async t => {
       d: D_PADDING
     };
 
-    assert.deepEqual(Array.from(Iterator.zipToObjects({
+    assert.deepEqual(Array.from(Iterator.zipKeyed({
       a: [0],
       b: [1, 2, 3],
     }, { mode: 'longest', padding })), [
@@ -145,7 +145,7 @@ test('padding', async t => {
       { a: A_PADDING, b: 3 },
     ]);
 
-    assert.deepEqual(Array.from(Iterator.zipToObjects({
+    assert.deepEqual(Array.from(Iterator.zipKeyed({
       a: [0],
       b: [1, 2, 3],
       c: [4, 5],


### PR DESCRIPTION
At today's TC39 plenary we reached consensus on renaming `Iterator.zipToObjects` to `Iterator.zipKeyed`. This PR makes the corresponding change to the proposal.

Closes #27 