### PR TITLE
refactor: use an alias for `iters[i]`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -135,17 +135,18 @@ copyright: false
         1. Let _results_ be a new empty List.
         1. Assert: _openIters_ is not empty.
         1. For each integer _i_ such that 0 ≤ _i_ &lt; _iterCount_, in ascending order, do
-          1. If _iters_[_i_] is *null*, then
+          1. Let _iter_ be _iters_[_i_].
+          1. If _iter_ is *null*, then
             1. Assert: _mode_ is *"longest"*.
             1. Let _result_ be _padding_[_i_].
           1. Else,
-            1. Let _result_ be Completion(IteratorStepValue(_iters_[_i_])).
+            1. Let _result_ be Completion(IteratorStepValue(_iter_)).
             1. If _result_ is an abrupt completion, then
-              1. Remove _iters_[_i_] from _openIters_.
+              1. Remove _iter_ from _openIters_.
               1. Return ? IteratorCloseAll(_openIters_, _result_).
             1. Set _result_ to ! _result_.
             1. If _result_ is ~done~, then
-              1. Remove _iters_[_i_] from _openIters_.
+              1. Remove _iter_ from _openIters_.
               1. If _mode_ is *"shortest"*, then
                 1. Return ? IteratorCloseAll(_openIters_, ReturnCompletion(*undefined*)).
               1. Else if _mode_ is *"strict"*, then


### PR DESCRIPTION
This feels cleaner and easier to read for me, and matches sequencing and others as well.