### PR TITLE
check for `~done~` enum for indicating iterator exhaustion

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -159,7 +159,7 @@ copyright: false
                     1. Remove _iters_[_k_] from _openIters_.
                     1. Return ? IteratorCloseAll(_openIters_, _open_).
                   1. Set _open_ to ! _open_.
-                  1. If _open_ is *false*, then
+                  1. If _open_ is ~done~, then
                     1. Remove _iters_[_k_] from _openIters_.
                   1. Else,
                     1. Return ? IteratorCloseAll(_openIters_, ThrowCompletion(a newly created *TypeError* object)).


### PR DESCRIPTION
Discovered by @ljharb.