### PR TITLE
make implementation spec-compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 /biblio.json
 /dist
+evaluated-test262.js

--- a/run-test262.mjs
+++ b/run-test262.mjs
@@ -1,0 +1,37 @@
+// assumes test262 is checked out in ../test262
+
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+let testDir = '../test262/test/built-ins/Iterator';
+let files = fs.readdirSync(testDir, { recursive: true });
+
+let harness =
+  fs.readFileSync('lib/index.js', 'utf8') +
+[
+  '../test262/harness/assert.js',
+  '../test262/harness/propertyHelper.js',
+  '../test262/harness/isConstructor.js',
+  '../test262/harness/compareArray.js',
+  '../test262/harness/testTypedArray.js',
+  '../test262/harness/proxyTrapsHelper.js',
+  '../test262/harness/wellKnownIntrinsicObjects.js',
+].map(x => fs.readFileSync(x, 'utf8')).join('\n') + `
+var $DETACHBUFFER = buff => buff.transfer();
+class Test262Error extends Error {}
+`;
+
+for (let file of files) {
+  if (!file.endsWith('.js')) continue;
+  let basic = fs.readFileSync(testDir + '/' + file, 'utf8');
+  if (!basic.includes('joint-iteration')) continue;
+  console.log(testDir + '/' + file);
+  let contents = harness + '\n(function(){ ' + basic + '})()';
+  try {
+    vm.runInContext(contents, vm.createContext({ console }));
+  } catch (e) {
+    fs.writeFileSync('evaluated-test262.js', contents, 'utf8');
+    console.log('evaluated-test262.js')
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ function getMode(options: ZipOptions<any>): Mode {
     mode = 'shortest';
   }
   if (mode !== 'shortest' && mode !== 'longest' && mode !== 'strict') {
-    throw new TypeError(`invalid mode`);
+    throw new TypeError('invalid mode');
   }
   return mode as Mode;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,11 +279,7 @@ function* zipCore(iters: Array<IteratorRecord | { done: true }>, mode: 'shortest
           }
         }
       }
-      // the tmpI dance is so that we still close iters[i] if `.return` is called during the `yield`
-      let tmpI = i;
-      i = -1;
       yield results;
-      i = tmpI;
     }
   } catch (e) {
     error = { error: e };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,27 +6,24 @@ if (typeof Iterator === 'undefined' || Iterator == null) {
 
 const DEFAULT_FILLER = undefined;
 
-function getIteratorFlattenable(obj: any, stringHandling: 'iterate-strings' | 'reject-strings'): Iterator<unknown> {
+function getIteratorFlattenable(obj: any, stringHandling: 'iterate-strings' | 'reject-strings'): IteratorRecord {
   if (Object(obj) !== obj) {
-    if (stringHandling === 'reject-strings' || typeof obj != 'string') {
-      throw new TypeError;
+    if (stringHandling === 'reject-strings' || typeof obj !== 'string') {
+      throw new TypeError('getIteratorFlattenable called on bad input');
     }
   }
-  let iter = Symbol.iterator in obj ? obj[Symbol.iterator]() : obj as Iterator<unknown>;
-  if (Object(iter) !== iter) {
-    throw new TypeError;
+  let method = obj[Symbol.iterator];
+  if (method != null && typeof method !== 'function') throw new TypeError('bad iterable');
+  let iter = method == null ? obj : method.call(obj);
+  if (!isObject(iter)) {
+    throw new TypeError('object is not iterator or an iterable');
   }
-  return iter;
+  let next = iter.next;
+  return { iter, next, done: false };
 }
 
 function isObject(obj: unknown): obj is Object {
   return Object(obj) === obj;
-}
-
-function getOwnEnumerablePropertyKeys<O extends Object>(obj: O): Array<keyof O> {
-  let descriptors = Object.getOwnPropertyDescriptors(obj);
-  let keys = Reflect.ownKeys(obj) as Array<keyof O>;
-  return keys.filter(k => descriptors[k].enumerable);
 }
 
 interface ZipShortestOptions {
@@ -47,6 +44,8 @@ type NamedIteratees<P  extends { readonly [item: PropertyKey]: IteratorOrIterabl
 // this layer of indirection is necessary until https://github.com/microsoft/TypeScript/issues/27995 gets fixed
 type IterateesOfTupleOfIterables<T extends readonly IteratorOrIterable<unknown>[]> = { -readonly [K in keyof T]: Iteratee<T[K]> }
 
+type IteratorRecord = { iter: Iterator<unknown>, next: Iterator<unknown>['next'], done: boolean }
+
 type Mode = 'shortest' | 'longest' | 'strict';
 
 function getMode(options: ZipOptions<any>): Mode {
@@ -55,148 +54,241 @@ function getMode(options: ZipOptions<any>): Mode {
     mode = 'shortest';
   }
   if (mode !== 'shortest' && mode !== 'longest' && mode !== 'strict') {
-    throw new TypeError;
+    throw new TypeError(`invalid mode`);
   }
   return mode as Mode;
+}
+
+function getPadding(options: ZipLongestOptions<any>): Object | undefined {
+  let padding = options.padding;
+  if (padding !== undefined && !isObject(padding)) {
+    throw new TypeError('padding must be an object');
+  }
+  return padding;
+}
+
+function IteratorCloseAll(iters: Array<{ done: boolean, iter: { return?: () => void } } | { done: true }>, error: { error: unknown } | null, skipIndex?: number) {
+  for (let k = iters.length - 1; k >= 0; --k) {
+    if (k === skipIndex) continue;
+    try {
+      let iterK = iters[k];
+      if (!iterK!.done) {
+        iterK!.iter.return?.();
+      }
+    } catch (e) {
+      if (error) continue;
+      error = { error: e };
+    }
+  }
+  if (error) throw error.error;
+}
+
+// @ts-expect-error Iterator helper types don't exist yet
+let IteratorHelperProto = (Iterator.from && Iterator.prototype?.drop) ? Object.getPrototypeOf(Iterator.from([]).drop(0)) : {};
+
+function wrapForIteratorHelperBehavior<T, S>(input: IterableIterator<Array<T>>, underlyingIterators: Array<IteratorRecord>, finalize: (vals: Array<T>) => S): IterableIterator<S> {
+  let state = 'suspended-start';
+  return {
+    // @ts-expect-error TS does not know about __proto__
+    __proto__: IteratorHelperProto,
+    [Symbol.iterator]() {
+      return this;
+    },
+    next(v) {
+      if (state !== 'suspended-start' && state !== 'suspended-yield') return { value: undefined, done: true };
+      state = 'suspended-yield';
+      let ret = input.next(v);
+      if (ret.done) return ret;
+      return { value: finalize(ret.value), done: false,  };
+    },
+    return(v) {
+      if (state === 'suspended-start') {
+        // we have to do this manually because generators do not run any code if `.return` is called before `.next`
+        state = 'completed';
+        IteratorCloseAll(underlyingIterators, null);
+        return { value: v, done: true };
+      }
+      try {
+        input.return!(v);
+        return { value: v, done: true };
+      } finally {
+        state = 'completed';
+      }
+    }
+  };
 }
 
 function zip(p: readonly [], o?: ZipOptions<Iterable<unknown>>): IterableIterator<never>
 function zip<P extends readonly IteratorOrIterable<unknown>[] | readonly []>(p: P, o?: ZipOptions<IterateesOfTupleOfIterables<P>>): IterableIterator<IterateesOfTupleOfIterables<P>>
 function zip<P extends Iterable<IteratorOrIterable<unknown>>>(p: P, o?: ZipOptions<Iteratee<P>>): IterableIterator<Array<Iteratee<Iteratee<P>>>>
-function* zip(input: unknown, options?: unknown): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
+function zip(input: unknown, options: unknown = undefined): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
+  if (new.target) {
+    throw new TypeError('not a constructor');
+  }
   if (!isObject(input)) {
-    throw new TypeError;
+    throw new TypeError('input must be an object');
   }
   if (options === undefined) {
     options = Object.create(null);
   }
   if (!isObject(options)) {
-    throw new TypeError;
+    throw new TypeError('options must be an object');
   }
   let mode = getMode(options);
-  let iters: Array<Iterator<unknown>> = [];
-  let padding: unknown[];
+  let paddingOption;
+  if (mode === 'longest') {
+    paddingOption = getPadding(options as ZipLongestOptions<unknown>);
+  }
+  let iters: Array<IteratorRecord> = [];
+  let padding: unknown[] = [];
+
+  let inputIterator = (input as Iterable<unknown>)[Symbol.iterator]();
+  let inputNext = inputIterator.next;
+  let errorInInputIterator = false;
   try {
-    for (let iter of (input as Iterable<unknown>)) {
-      iters.push(getIteratorFlattenable(iter, 'iterate-strings'));
+    let done, value;
+    errorInInputIterator = true;
+    while (({ done, value } = inputNext.call(inputIterator), !done)) {
+      errorInInputIterator = false;
+      iters.push(getIteratorFlattenable(value, 'reject-strings'));
+      errorInInputIterator = true;
     }
-    padding = iters.map(() => DEFAULT_FILLER);
     if (mode === 'longest') {
-      let tmp = (options as ZipLongestOptions<Iterable<unknown>>).padding;
-      if (tmp != null) {
-        padding = Array.from(tmp);
+      if (paddingOption === undefined) {
+        padding = iters.map(() => DEFAULT_FILLER);
+      } else {
+        let paddingIter = (paddingOption as Iterable<unknown>)[Symbol.iterator]();
+        let nextFn = paddingIter.next;
+        let usingIterator = true;
+        for (let i = 0; i < iters.length; ++i) {
+          if (usingIterator) {
+            let next = nextFn.call(paddingIter);
+            if (next.done) {
+              usingIterator = false;
+            } else {
+              padding.push(next.value);
+            }
+          }
+          if (!usingIterator) {
+            padding.push(undefined);
+          }
+        }
+        if (usingIterator) {
+          paddingIter.return?.();
+        }
       }
     }
   } catch (e) {
-    for (let iter of iters) {
-      try {
-        iter.return?.();
-      } catch {}
-    }
-    throw e;
+    let toClose = errorInInputIterator ? iters : [{ done: false, iter: inputIterator }, ...iters];
+    IteratorCloseAll(toClose, { error: e });
   }
-  yield* zipCore(iters, mode, padding);
+  return wrapForIteratorHelperBehavior(zipCore(iters, mode, padding), iters, x => x);
 }
 
 function zipKeyed<P extends { readonly [item: PropertyKey]: IteratorOrIterable<unknown> }>(p: P, o?: ZipOptions<NamedIteratees<P>>): IterableIterator<NamedIteratees<P>>
-function* zipKeyed(input: unknown, options?: unknown): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
+function zipKeyed(input: unknown, options: unknown = undefined): IterableIterator<Array<unknown> | { [k: PropertyKey]: unknown }> {
+  if (new.target) {
+    throw new TypeError('not a constructor');
+  }
   if (!isObject(input)) {
-    throw new TypeError;
+    throw new TypeError('input must be an object');
   }
   if (options === undefined) {
     options = Object.create(null);
   }
   if (!isObject(options)) {
-    throw new TypeError;
+    throw new TypeError('options must be an object');
   }
   let mode = getMode(options);
-  let keys = getOwnEnumerablePropertyKeys(input);
-  let padding: Array<unknown> = keys.map(() => DEFAULT_FILLER);
-  let iters: Array<Iterator<unknown>> = [];
+  let paddingOption;
+  if (mode === 'longest') {
+    paddingOption = getPadding(options as ZipLongestOptions<unknown>);
+  }
+  let iters: Array<IteratorRecord> = [];
+  let padding: Array<unknown> = [];
+  let allKeys = Reflect.ownKeys(input);
+  let keys: Array<PropertyKey> = [];
   try {
-    for (let k of keys) {
-      iters.push(getIteratorFlattenable(input[k], 'iterate-strings'));
+    for (let k of allKeys) {
+      let desc = Object.getOwnPropertyDescriptor(input, k);
+      if (desc?.enumerable) {
+        let value = (input as Record<PropertyKey, unknown>)[k];
+        if (value !== undefined) {
+          keys.push(k);
+          iters.push(getIteratorFlattenable(value, 'reject-strings'));
+        }
+      }
     }
     if (mode === 'longest') {
-      let tmp = (options as ZipLongestOptions<{ [k: PropertyKey]: unknown }>).padding;
-      if (tmp != null) {
-        padding = keys.map(k => tmp![k]);
+      if (paddingOption === undefined) {
+        padding = keys.map(() => DEFAULT_FILLER);
+      } else {
+        for (let k of keys) {
+          padding.push((paddingOption as Record<PropertyKey, unknown>)[k]);
+        }
       }
     }
   } catch (e) {
-    for (let iter of iters) {
-      try {
-        iter.return?.();
-      } catch {}
-    }
-    throw e;
+    IteratorCloseAll(iters, { error: e });
   }
-  for (let result of zipCore(iters, mode, padding)) {
-    yield Object.fromEntries(result.map((r, i) => [keys[i], r]));
-  }
+  return wrapForIteratorHelperBehavior(zipCore(iters, mode, padding), iters, vs => Object.setPrototypeOf(Object.fromEntries(vs.map((r, i) => [keys[i], r])), null));
 }
 
-type Nexts = Array<{ done: false, next: () => { done?: boolean, value?: unknown } } | { done: true, next?: void }>;
-
-function getResults(iters: Array<Iterator<unknown>>, nexts: Nexts): Array<{ done: true, value?: undefined } | { done: false, value: unknown }> {
-  return nexts.map(({done, next}, i) => {
-    if (done) return { done: true };
-    try {
-      let v = next.call(iters[i]);
-      return v.done ? { done: true } : { done: false, value: v.value };
-    } catch (e) {
-      for (let k = 0; k < nexts.length; ++k) {
-        if (k === i) continue;
-        try {
-          if (!nexts[k]!.done) {
-            iters[k]!.return?.();
-          }
-        } catch {}
-      }
-      throw e;
-    }
-  });
-}
-
-function* zipCore(iters: Array<Iterator<unknown>>, mode: 'shortest' | 'longest' | 'strict', padding: Array<unknown>) {
+function* zipCore(iters: Array<IteratorRecord | { done: true }>, mode: 'shortest' | 'longest' | 'strict', padding: Array<unknown>) {
   if (iters.length === 0) return;
-  let nexts: Nexts = iters.map((iter, i) => {
-    try {
-      return ({ done: false, next: iter.next });
-    } catch (e) {
-      for (let k = 0; k < iters.length; ++k) {
-        if (k === i) continue;
-        try {
-          iters[k]!.return?.();
-        } catch {}
-      }
-      throw e;
-    }
-  });
-  while (true) {
-    let results = getResults(iters, nexts);
-    results.forEach((r, i) => {
-      if (r.done) {
-        nexts[i] = { done: true };
-      }
-    });
-    switch (mode) {
-      case 'shortest':
-        if (results.some(r => r.done)) return;
-        yield results.map(r => r.value);
-        break;
-      case 'longest':
-        if (results.every(r => r.done)) return;
-        yield results.map((r, i) => r.done ? padding[i] : r.value);
-        break;
-      case 'strict':
-        if (results.every(r => r.done)) return;
-        if (results.some(r => r.done)) {
-          throw new RangeError;
+  let i = -1;
+  let error: { error: unknown } | null = null;;
+  try {
+    while (true) {
+      let results = [];
+      for (i = 0; i < iters.length; ++i) {
+        let iter = iters[i]!;
+        if (iter.done) {
+          console.assert(mode === 'longest');
+          results.push(padding[i]);
+        } else {
+          let iterResult = iter.next.call(iter.iter);
+          if (iterResult.done) {
+            iter.done = true;
+            if (mode === 'shortest') {
+              return;
+            } else if (mode === 'strict') {
+              if (i !== 0) {
+                throw new TypeError('mode was strict, but iterators were not all same length');
+              }
+              for (i = 1; i < iters.length; ++i) {
+                let toCheck = iters[i]!;
+                console.assert(!toCheck.done);
+                let { done } = (toCheck as IteratorRecord).next.call((toCheck as IteratorRecord).iter);
+                if (done) {
+                  toCheck.done = true;
+                } else {
+                  i = -1; // so we still close this iterator
+                  throw new TypeError('mode was strict, but iterators were not all same length');
+                }
+              }
+              return;
+            } else {
+              console.assert(mode === 'longest');
+              if (iters.every(r => r.done)) return;
+              iters[i]!.done = true;
+              results.push(padding[i]);
+            }
+          } else {
+            results.push(iterResult.value);
+          }
         }
-        yield results.map(r => r.value);
-        break;
+      }
+      // the tmpI dance is so that we still close iters[i] if `.return` is called during the `yield`
+      let tmpI = i;
+      i = -1;
+      yield results;
+      i = tmpI;
     }
+  } catch (e) {
+    error = { error: e };
+  } finally {
+    IteratorCloseAll(iters, error, i);
   }
 }
 

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -46,7 +46,7 @@ test('basic positional', async t => {
       ], { mode: 'strict' });
     assert.throws(() => {
       Array.from(result);
-    }, RangeError);
+    }, TypeError);
   });
 });
 
@@ -56,7 +56,7 @@ test('basic named', async t => {
       a: [0],
       b: [1, 2],
     })), [
-      { a: 0,  b: 1 },
+      { a: 0,  b: 1, __proto__: null },
     ]);
   });
 
@@ -66,9 +66,9 @@ test('basic named', async t => {
       b: [3, 4, 5],
       c: [6, 7, 8],
     })), [
-      { a: 0, b: 3, c: 6 },
-      { a: 1, b: 4, c: 7 },
-      { a: 2, b: 5, c: 8 },
+      { a: 0, b: 3, c: 6, __proto__: null },
+      { a: 1, b: 4, c: 7, __proto__: null },
+      { a: 2, b: 5, c: 8, __proto__: null },
     ]);
   });
 
@@ -81,8 +81,8 @@ test('basic named', async t => {
       a: [0],
       b: [1, 2],
     }, { mode: 'longest' })), [
-      { a: 0, b: 1 },
-      { a: undefined, b: 2 },
+      { a: 0, b: 1, __proto__: null },
+      { a: undefined, b: 2, __proto__: null },
     ]);
   });
 
@@ -94,7 +94,7 @@ test('basic named', async t => {
       }, { mode: 'strict' });
     assert.throws(() => {
       Array.from(result);
-    }, RangeError);
+    }, TypeError);
   });
 });
 
@@ -140,9 +140,9 @@ test('padding', async t => {
       a: [0],
       b: [1, 2, 3],
     }, { mode: 'longest', padding })), [
-      { a: 0, b: 1 },
-      { a: A_PADDING, b: 2 },
-      { a: A_PADDING, b: 3 },
+      { a: 0, b: 1, __proto__: null },
+      { a: A_PADDING, b: 2, __proto__: null },
+      { a: A_PADDING, b: 3, __proto__: null },
     ]);
 
     assert.deepEqual(Array.from(Iterator.zipKeyed({
@@ -151,9 +151,9 @@ test('padding', async t => {
       c: [4, 5],
       d: [],
     }, { mode: 'longest', padding })), [
-      { a: 0, b: 1, c: 4, d: D_PADDING },
-      { a: A_PADDING, b: 2, c: 5, d: D_PADDING },
-      { a: A_PADDING, b: 3, c: C_PADDING, d: D_PADDING },
+      { a: 0, b: 1, c: 4, d: D_PADDING, __proto__: null },
+      { a: A_PADDING, b: 2, c: 5, d: D_PADDING, __proto__: null },
+      { a: A_PADDING, b: 3, c: C_PADDING, d: D_PADDING, __proto__: null },
     ]);
   });
 });


### PR DESCRIPTION
Mainly so that I could exercise [the tests](https://github.com/tc39/test262/pull/). Which worked; tests all pass with this implementation and I've added a runner you can use to check yourself assuming that the branch for that PR is checked out in `../test262`.

It's definitely not as pretty but I don't think it really matters. I can split it into its own file and keep the original if you really want but I don't think the original is all that readable for most people anyway. If so some of the changes should be ported; notably the original has RangeErrors instead of TypeErrors in two places and uses `iterate-strings` instead of `reject-strings`.